### PR TITLE
Reduce legacy check to one line

### DIFF
--- a/git-plugin-updates.php
+++ b/git-plugin-updates.php
@@ -45,11 +45,7 @@ if (
 	 * @var string Absolute path to this file.
 	 */
 	define( 'GPU_PLUGIN_FILE', __FILE__ );
-
-	/**
-	 * @var string Absolute path to the root plugin directory
-	 */
-	define( 'GPU_PLUGIN_DIR', dirname( __FILE__ ) );
+	
 
 	/**
 	 * Load plugin dependencies and instantiate the plugin.

--- a/git-plugin-updates.php
+++ b/git-plugin-updates.php
@@ -44,45 +44,32 @@ if ( !defined( 'GPU_PLUGIN_FILE') )
 if ( !defined( 'GPU_PLUGIN_DIR' ) )
 	define( 'GPU_PLUGIN_DIR', dirname( __FILE__ ) );
 
+
 /**
- * Load plugin dependencies and instantiate the plugin.
- * Checks PHP version. Deactivates plugin and links to instructions if running PHP 4.
+ * Verify that update library not already included by another plugin.
+ * Verify that we're running WordPress 3.2 (which enforces PHP 5.2.4).
+ * Verify we're in wp-admin -- plugin doesn't need to load in front-end.
  */
-function storm_git_plugin_updates_init() {
-	
-	// PHP Version Check
-	$php_is_outdated = version_compare( PHP_VERSION, '5.2', '<' );
+if (
+	!function_exists( 'gpu_git_plugin_updates_init' ) && !class_exists( 'GPU_Controller' )
+	&& version_compare( $wp_version, '3.2', '>=' )
+	&& is_admin()
+) :
 
-	// Only exit and warn if on admin page
-	$okay_to_exit = is_admin() && ( !defined('DOING_AJAX') || !DOING_AJAX );
-	
-	if ( $php_is_outdated ) {
-		if ( $okay_to_exit ) {
-			require_once ABSPATH . '/wp-admin/includes/plugin.php';
-			deactivate_plugins( __FILE__ );
-			wp_die( sprintf( __(
-				'%s requires PHP 5.2 or higher, as does WordPress 3.2 and higher. The plugin has now disabled itself. For information on upgrading, %ssee this article%s.', GHPS_PLUGIN_SLUG ),
-				GPU_PLUGIN_NAME,
-				'<a href="http://codex.wordpress.org/Switching_to_PHP5" target="_blank">',
-				'</a>'
-			) );
-		} else {
-			return;
-		}
-	}
-
-	// Be cautious, since this class might be included by multiple plugins.
-	if ( is_admin() && !class_exists( 'GPU_Controller') ) {
+	/**
+	 * Load plugin dependencies and instantiate the plugin.
+	 */
+	function gpu_git_plugin_updates_init() {
 
 		require_once dirname( __FILE__ ) . '/includes/class-controller.php';
 		require_once dirname( __FILE__ ) . '/includes/class-updater.php';
 		require_once dirname( __FILE__ ) . '/includes/class-updater-github.php';
 		require_once dirname( __FILE__ ) . '/includes/class-updater-bitbucket.php';
-		
+
 		GPU_Controller::get_instance();
 
 	}
 
-}
+	add_action( 'plugins_loaded', 'gpu_git_plugin_updates_init' );
 
-add_action( 'plugins_loaded', 'storm_git_plugin_updates_init' );
+endif;

--- a/git-plugin-updates.php
+++ b/git-plugin-updates.php
@@ -15,46 +15,41 @@ License: GPLv2
  */
 
 /**
- * Used for localization text-domain, which must match wp.org slug.
- * Used for wp-admin settings page slug.
- * 
- * @var string Slug of the plugin on wordpress.org.
- */
-if ( !defined( 'GPU_PLUGIN_SLUG') )
-	define( 'GPU_PLUGIN_SLUG', 'git-plugin-updates' );
-
-/**
- * Used for error messages.
- * Used for settings page title.
- * 
- * @var string Nice name of the plugin.
- */
-if ( !defined( 'GPU_PLUGIN_NAME') )
-	define( 'GPU_PLUGIN_NAME', __( 'Git Plugin Updates', GPU_PLUGIN_SLUG ) );
-
-/**
- * @var string Absolute path to this file.
- */
-if ( !defined( 'GPU_PLUGIN_FILE') )
-	define( 'GPU_PLUGIN_FILE', __FILE__ );
-
-/**
- * @var string Absolute path to the root plugin directory
- */
-if ( !defined( 'GPU_PLUGIN_DIR' ) )
-	define( 'GPU_PLUGIN_DIR', dirname( __FILE__ ) );
-
-
-/**
  * Verify that update library not already included by another plugin.
  * Verify that we're running WordPress 3.2 (which enforces PHP 5.2.4).
  * Verify we're in wp-admin -- plugin doesn't need to load in front-end.
  */
 if (
-	!function_exists( 'gpu_git_plugin_updates_init' ) && !class_exists( 'GPU_Controller' )
+	!class_exists( 'GPU_Controller' )
 	&& version_compare( $wp_version, '3.2', '>=' )
 	&& is_admin()
 ) :
+
+	/**
+	 * Used for localization text-domain, which must match wp.org slug.
+	 * Used for wp-admin settings page slug.
+	 * 
+	 * @var string Slug of the plugin on wordpress.org.
+	 */
+	define( 'GPU_PLUGIN_SLUG', 'git-plugin-updates' );
+
+	/**
+	 * Used for error messages.
+	 * Used for settings page title.
+	 * 
+	 * @var string Nice name of the plugin.
+	 */
+	define( 'GPU_PLUGIN_NAME', __( 'Git Plugin Updates', GPU_PLUGIN_SLUG ) );
+
+	/**
+	 * @var string Absolute path to this file.
+	 */
+	define( 'GPU_PLUGIN_FILE', __FILE__ );
+
+	/**
+	 * @var string Absolute path to the root plugin directory
+	 */
+	define( 'GPU_PLUGIN_DIR', dirname( __FILE__ ) );
 
 	/**
 	 * Load plugin dependencies and instantiate the plugin.

--- a/git-plugin-updates.php
+++ b/git-plugin-updates.php
@@ -20,9 +20,9 @@ License: GPLv2
  * Verify we're in wp-admin -- plugin doesn't need to load in front-end.
  */
 if (
-	!class_exists( 'GPU_Controller' )
+	is_admin()
+	&& !class_exists( 'GPU_Controller' )
 	&& version_compare( $wp_version, '3.2', '>=' )
-	&& is_admin()
 ) :
 
 	/**

--- a/git-plugin-updates.php
+++ b/git-plugin-updates.php
@@ -26,7 +26,6 @@ if (
 ) :
 
 	/**
-	 * Used for localization text-domain, which must match wp.org slug.
 	 * Used for wp-admin settings page slug.
 	 * 
 	 * @var string Slug of the plugin on wordpress.org.
@@ -39,7 +38,7 @@ if (
 	 * 
 	 * @var string Nice name of the plugin.
 	 */
-	define( 'GPU_PLUGIN_NAME', __( 'Git Plugin Updates', GPU_PLUGIN_SLUG ) );
+	define( 'GPU_PLUGIN_NAME', __( 'Git Plugin Updates', 'git-plugin-updates' ) );
 
 	/**
 	 * @var string Absolute path to this file.

--- a/includes/class-controller.php
+++ b/includes/class-controller.php
@@ -365,8 +365,8 @@ class GPU_Controller {
 		$activate = activate_plugin( WP_PLUGIN_DIR . '/' . $plugin->slug );
 
 		// Output the update message
-		$fail		= __('The plugin has been updated, but could not be reactivated. Please reactivate it manually.', GPU_PLUGIN_SLUG );
-		$success	= __('Plugin reactivated successfully.', GPU_PLUGIN_SLUG );
+		$fail		= __('The plugin has been updated, but could not be reactivated. Please reactivate it manually.', 'git-plugin-updates' );
+		$success	= __('Plugin reactivated successfully.', 'git-plugin-updates' );
 
 		echo is_wp_error( $activate ) ? $fail : $success;
 		return $result;

--- a/includes/class-controller.php
+++ b/includes/class-controller.php
@@ -128,7 +128,7 @@ class GPU_Controller {
 	public static function get_template( $file, $args = array() ) {
 		extract( $args );
 
-		include GPU_PLUGIN_DIR . "/views/$file.php";
+		include dirname( dirname( __FILE__ ) ) . "/views/$file.php";
 
 	}
 


### PR DESCRIPTION
Because effected users would have this library loaded in other plugins,
there isn't any point in running `deactivate_plugins` or `wp_die`.

By requiring WordPress 3.2, we also inherantly require PHP5,
so check of PHP_VERSION is not needed.

By checking `$wp_version` outside `gpu_git_plugin_updates_init`, we
can combine all checks into one `if` statement, and don't need
to declare `global $wp_version`.

Because users not running WordPress older than 3.2 _already_ have
an update nag displaying, there's no point in displaying an
update notice. Because they're already habitually ignoring upgrades,
it's okay for this plugin to silently not do anything until
WordPress core is upgraded.

Ideas for this commit came about while working through
@afragen's [pull request](https://github.com/afragen/git-plugin-updates/commit/d0315f6c95711d2ccece5068b94536f152b17242) for issue #12.
